### PR TITLE
Handle 404 when fetching PDF + bump dependencies

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -19,11 +19,11 @@ jobs:
 
       - name: Set up Docker Buildx
         id: docker-setup-buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Docker metadata
         id: docker-meta
-        uses: docker/metadata-action@v3
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/dlcs/pdf-to-alto
           tags: |
@@ -36,7 +36,7 @@ jobs:
 
       - name: Login to GitHub Container Registry
         id: docker-login
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Build and push
         id: docker-build-push
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v4
         with:
           context: .
           builder: ${{ steps.docker-setup-buildx.outputs.name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,19 @@
-FROM debian:bullseye as build
-
-# avoid issue with packages requiring interaction (e.g. tzdata)
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt-get update && apt-get install -y wget cmake clang git autoconf pkg-config
-
-# Change submodule to https as we're cloning only. Avoids issues with ssh
-# 8bb209c0c21476ee904a is 0.4 with some bugfixes
-RUN mkdir /home/pdfalto && cd /home/pdfalto \
-    && git clone https://github.com/kermitt2/pdfalto.git && cd pdfalto && git checkout 8bb209c0c21476ee904a && ./install_deps.sh \
-    && git submodule set-url xpdf-4.03 https://github.com/kermitt2/xpdf-4.03.git && git submodule update --init --recursive \
-    && cmake ./ && make
-
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>"
 LABEL org.opencontainers.image.source=https://github.com/dlcs/pdf-to-alto
 LABEL org.opencontainers.image.description="Extract ALTO from PDF"
 
-COPY --from=build  /home/pdfalto/pdfalto/pdfalto /usr/bin/pdfalto
+COPY /deps/pdfalto /usr/bin/pdfalto
 
 COPY requirements.txt /opt/app/requirements.txt
 
 WORKDIR /opt/app
 RUN pip install --no-cache-dir -r requirements.txt
-COPY . /opt/app
+
+COPY app /opt/app/app
+COPY monitor.py /opt/app/monitor.py
+COPY wait-for-localstack.sh /opt/app/wait-for-localstack.sh
 
 RUN chmod +x wait-for-localstack.sh
 

--- a/app/pdf_processor.py
+++ b/app/pdf_processor.py
@@ -82,6 +82,8 @@ class PDFProcessor:
     def _download_pdf(self, target_file: Path):
         try:
             download_request = requests.get(self.pdf_location, stream=True)
+            download_request.raise_for_status()
+
             with open(target_file, "wb") as file:
                 for chunk in download_request.iter_content(DOWNLOAD_CHUNK_SIZE):
                     file.write(chunk)

--- a/compose/localstack/Dockerfile
+++ b/compose/localstack/Dockerfile
@@ -1,2 +1,2 @@
-FROM localstack/localstack
-COPY seed-resources.sh /docker-entrypoint-initaws.d/
+FROM localstack/localstack:2.2.0
+COPY seed-resources.sh /etc/localstack/init/ready.d/

--- a/deps/readme.md
+++ b/deps/readme.md
@@ -1,0 +1,18 @@
+# Dependencies
+
+pdfalto is a required binary from https://github.com/kermitt2/pdfalto.git. Built using:
+
+```dockerfile
+FROM debian:bullseye as build
+
+# avoid issue with packages requiring interaction (e.g. tzdata)
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y wget cmake clang git autoconf pkg-config
+
+# Change submodule to https as we're cloning only. Avoids issues with ssh
+# 8bb209c0c21476ee904a is 0.4 with some bugfixes
+RUN mkdir /home/pdfalto && cd /home/pdfalto \
+    && git clone https://github.com/kermitt2/pdfalto.git && cd pdfalto && git checkout 8bb209c0c21476ee904a && ./install_deps.sh \
+    && git submodule set-url xpdf-4.03 https://github.com/kermitt2/xpdf-4.03.git && git submodule update --init --recursive \
+    && cmake ./ && make
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,9 +6,9 @@ colorama==0.4.4
 idna==3.3
 jmespath==0.10.0
 logzero==1.7.0
-lxml==4.7.1
+lxml==4.9.3
 pycryptodome==3.12.0
-PyMuPDF==1.19.4
+PyMuPDF==1.22.5
 python-dateutil==2.8.2
 requests==2.27.1
 s3transfer==0.5.0


### PR DESCRIPTION
Changes were originally to better handle errors. There were log entries about corrupt PDFs but it was due to 404's not being correctly handled so the resulting file was an HTML blob - fix was to add `download_request.raise_for_status()` and abort processing if encountered. As part of implementing + testing I bumped a few python dependencies.

Also resolved #2, but rather forking pdf-alto lib I added the generated binary to `/deps` folder. Originally a multi stage Docker build built this and copied it over but it took a _long_ time. This change simplifies + speeds up the build at the cost of having a large binary in repo.

Resolved #3 too as part of update work, this pins the Localstack Dockerfile to a known version and uses latest init.d folder format.